### PR TITLE
lint: add basic configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,86 @@
+# clang-format configuration file
+#
+# Please seek consensus from the team before modifying this file.
+#
+# To compare these settings with all available clang-format options:
+# diff <(clang-format -dump-config | grep -Ev '^$|^( |BraceWrapping|IncludeCategories)' | sed -Ee 's/: +/: /g' | sort) <(cat .clang-format | grep -Ev '^$|^#' | sort) | colordiff
+#
+---
+DisableFormat: false
+Language: Cpp
+Standard: Cpp11
+
+# Indentation & whitespace
+AccessModifierOffset: -4
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+IndentExternBlock: NoIndent
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+SpacesBeforeTrailingComments: 2
+TabWidth: 4
+UseTab: Never
+
+# Spacing style
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Comments
+AlignTrailingComments: true
+CommentPragmas: ''
+FixNamespaceComments: true
+ReflowComments: true
+
+# Pattern-based special behavior
+ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: []
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+SortIncludes: false
+
+# Alignment & breaking
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowAllArgumentsOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BreakStringLiterals: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+
+# Prevent return type from being on a line of its own
+PenaltyReturnTypeOnItsOwnLine: 1000
+...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,67 @@
+# EditorConfig: https://editorconfig.org/
+
+# top-most EditorConfig file
+root = true
+
+# All (Defaults)
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+# C
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+
+# C++
+[*.{cpp,hpp}]
+indent_style = space
+indent_size = 4
+
+# Python
+[*.py]
+indent_style = space
+indent_size = 4
+
+# reStructuredText
+[*.rst]
+indent_style = space
+indent_size = 4
+
+# YAML
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# Shell Script
+[*.sh]
+indent_style = space
+indent_size = 4
+
+# CMake
+[{CMakeLists.txt,*.cmake}]
+indent_style = space
+indent_size = 4
+
+# Makefile
+[Makefile]
+indent_style = tab
+indent_size = 8
+
+# Git commit messages
+[COMMIT_EDITMSG]
+max_line_length = 75
+
+# Kconfig
+[Kconfig*]
+indent_style = space
+indent_size = 4
+
+# Markdown
+[*.md]
+indent_style = space
+indent_size = 2
+max_line_length = 72

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,7 @@
+[general]
+# Set the extra-path where gitlint will search for user defined rules
+# See http://jorisroovers.github.io/gitlint/user_defined_rules for details
+extra-path=scripts/gitlint
+
+[body-max-line-length]
+line-length=75

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: forbid-crlf

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+extends: default
+
+rules:
+  line-length:
+    max: 100
+
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+  document-start:
+    present: false
+  truthy:
+    check-keys: false


### PR DESCRIPTION
This allows for basic check of source code files and later reuse in CI workflow files.

Part of #3 