### PR TITLE
boards: bsim_*: drop 'full_name'

### DIFF
--- a/boards/bsim_2G4_phy/board.yml
+++ b/boards/bsim_2G4_phy/board.yml
@@ -1,6 +1,5 @@
 boards:
 - name: bsim_2G4_phy
-  full_name: BabbleSim 2G4 Phy
   vendor: zephyr
   socs:
   - name: native

--- a/boards/bsim_device/board.yml
+++ b/boards/bsim_device/board.yml
@@ -1,6 +1,5 @@
 boards:
   - name: bsim_device
-    full_name: BabbleSim device
     vendor: zephyr
     socs:
       - name: native


### PR DESCRIPTION
Drop them, since they are not useful.

Part of https://github.com/golioth/bluetooth-gateway/pull/3