### PR TITLE
Include empty app image in nRF5340 build on Thingy:91 X

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ west config manifest.file west-thingy91x-controller.yml && west update
 west forall zephyr -c "git am $(west topdir)/bluetooth-gateway/zephyr/patches/thingy91x-controller/zephyr/*.patch"
 ```
 
-Bluetooth controller is running on nRF5340. This means that proper
+Bluetooth controller is running on the nRF5340 NET core. This means that proper
 firmware needs to be flashed (HCI controller over UART) in order to
 access Bluetooth from nRF9151 chip.
 
@@ -46,12 +46,12 @@ This is done by by changing `SWD` switch from `nRF91` to `nRF53` on
 Thingy, then building and flashing firmware with:
 
 ```
-west build -p -b thingy91x/nrf5340/cpunet bluetooth-gateway/controller --sysbuild -- -DSB_CONFIG_THINGY91X_NO_PREDEFINED_LAYOUT=y
+west build -p -b thingy91x/nrf5340/cpunet bluetooth-gateway/controller --sysbuild
 west flash
 ```
 
 Gateway firmware runs on nRF9151 chip. There is direct access to LTE
-modem and also Bluetooth Host stack, which communicats with Bluetooth
+modem and also Bluetooth Host stack, which communicates with Bluetooth
 Controller over UART. Build and flash it with:
 
 ```

--- a/controller/sysbuild.conf
+++ b/controller/sysbuild.conf
@@ -1,0 +1,2 @@
+SB_CONFIG_APPCORE_EMPTY=y # Add empty app core image on nRF5340 builds
+SB_CONFIG_THINGY91X_NO_PREDEFINED_LAYOUT=y


### PR DESCRIPTION
As pointed out by Dan in #8, the controller build for the Thingy:91 X was missing an app core image, which is required to be able to boot up the net core properly. This likely didn't get detected in testing due to lingering empty app images from previous builds. By adding a sysbuild config for the controller, we can force an app image to be included in the sysbuild and also get rid of the command line sysbuild config outlined in the readme.

**I need someone to verify that this actually works on target, as I don't have a Thingy:91 X. Remember to do a factory reset of the nRF5340 app core first, so that we can ensure that the configuration is sufficient for this to work out of the box.**