### PR TITLE
gateway: bt: scan: fix -Wparentheses

### DIFF
--- a/gateway/src/bt/scan.c
+++ b/gateway/src/bt/scan.c
@@ -24,7 +24,7 @@ static inline bool version_is_compatible(const struct golioth_ble_gatt_adv_data 
 
 static inline bool sync_requested(const struct golioth_ble_gatt_adv_data *adv_data)
 {
-    return (0 != adv_data->flags & GOLIOTH_BLE_GATT_ADV_FLAG_SYNC_REQUEST);
+    return (adv_data->flags & GOLIOTH_BLE_GATT_ADV_FLAG_SYNC_REQUEST);
 }
 
 struct tf_data


### PR DESCRIPTION
Fixes:

```
/gateway/src/bt/scan.c: In function ‘sync_requested’:
/gateway/src/bt/scan.c:27:15: warning: suggest parentheses around comparison in operand of ‘&’ [-Wparentheses]
   27 |     return (0 != adv_data->flags & GOLIOTH_BLE_GATT_ADV_FLAG_SYNC_REQUEST);
      |             ~~^~~~~~~~~~~~~~~~~~
```

as the above expression is equivalent to:

```
return ((0 != adv_data->flags) & GOLIOTH_BLE_GATT_ADV_FLAG_SYNC_REQUEST);
```