### PR TITLE
gateway: sysbuild: use ${ZEPHYR_POUCH_MODULE_DIR}

### DIFF
--- a/gateway/sysbuild.cmake
+++ b/gateway/sysbuild.cmake
@@ -49,5 +49,5 @@ if(BOARD MATCHES "bsim")
   add_peripheral(periodic_uplink
     ${ZEPHYR_BLUETOOTH_GATEWAY_MODULE_DIR}/samples/peripheral/periodic_uplink)
   add_peripheral(ble_gatt_example
-    ${ZEPHYR_BLUETOOTH_GATEWAY_MODULE_DIR}/../pouch/examples/ble_gatt)
+    ${ZEPHYR_POUCH_MODULE_DIR}/examples/ble_gatt)
 endif()


### PR DESCRIPTION
This is the path to 'pouch' repo without any indirection.