### PR TITLE
bt: uplink: optimize log messages for flash footprint

### DIFF
--- a/gateway/src/bt/uplink.c
+++ b/gateway/src/bt/uplink.c
@@ -30,7 +30,7 @@ static uint8_t tf_uplink_read_cb(struct bt_conn *conn,
 {
     if (err)
     {
-        LOG_ERR("Failed to read BLE GATT Uplink (err %d)", err);
+        LOG_ERR("Failed to read BLE GATT %s (err %d)", "Uplink", err);
         return BT_GATT_ITER_STOP;
     }
 
@@ -41,7 +41,7 @@ static uint8_t tf_uplink_read_cb(struct bt_conn *conn,
         golioth_ble_gatt_packetizer_decode(data, length, &payload, &is_first, &is_last);
     if (payload_len < 0)
     {
-        LOG_ERR("Failed to decode BLE GATT Uplink (err %d)", (int) payload_len);
+        LOG_ERR("Failed to decode BLE GATT %s (err %d)", "Uplink", (int) payload_len);
         bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
         return BT_GATT_ITER_STOP;
     }


### PR DESCRIPTION
The same format is already used for certificate module, so reuse it for
uplink as well. This will save some flash space.