### PR TITLE
block: use memslab for block allocation

### DIFF
--- a/gateway/Kconfig
+++ b/gateway/Kconfig
@@ -23,11 +23,27 @@ config GATEWAY_UPLINK_TIMEOUT
 
 endif # GATEWAY_CLOUD
 
+config GATEWAY_NUM_BLOCKS
+    int "Number of blocks in downlink/uplink buffer"
+    default 32
+    help
+      The number of blocks available for buffering uplink or downlink
+      data between a node device and the cloud. Each block is equal
+      to CONFIG_GOLIOTH_BLOCKWISE_UPLOAD_MAX_BLOCK_SIZE in length.
+
 config GATEWAY_SERVER_CERT_MAX_LEN
     int "Server certificate maximum length"
     default 4096
     help
       Maximum length of server certificate.
+
+config GATEWAY_DOWNLINK_BLOCK_TIMEOUT
+    int "Downlink timeout"
+    default 10
+    help
+      The time in seconds that the downlink module will wait for a
+      block to become available in the buffer. This should be larger
+      than the duration it takes to send one block to the node device.
 
 config GATEWAY_SERVER_CERT_BUILTIN
     bool

--- a/gateway/src/block.h
+++ b/gateway/src/block.h
@@ -6,9 +6,11 @@
 
 #include <stdbool.h>
 
+#include <zephyr/kernel.h>
+
 struct block;
 
-struct block *block_alloc(void *user_data, size_t size);
+struct block *block_alloc(void *user_data, size_t size, k_timeout_t timeout);
 void block_free(struct block *block);
 size_t block_length(const struct block *block);
 void block_mark_last(struct block *block);

--- a/gateway/src/downlink.c
+++ b/gateway/src/downlink.c
@@ -52,7 +52,7 @@ enum golioth_status downlink_block_cb(const uint8_t *data, size_t len, bool is_l
         return GOLIOTH_ERR_NACK;
     }
 
-    struct block *block = block_alloc(NULL, len);
+    struct block *block = block_alloc(NULL, len, K_SECONDS(CONFIG_GATEWAY_DOWNLINK_BLOCK_TIMEOUT));
     if (NULL == block)
     {
         LOG_ERR("Failed to allocate block");


### PR DESCRIPTION
Use a memory slab instead of malloc for allocating blocks. This ensures we do not exhaust memory with an unbounded number of allocations and allows us to stall the downlink block download.