### PR TITLE
bt: scan: use local var for connection reference

### DIFF
--- a/gateway/src/bt/scan.c
+++ b/gateway/src/bt/scan.c
@@ -33,8 +33,6 @@ struct tf_data
     struct golioth_ble_gatt_adv_data adv_data;
 };
 
-static struct bt_conn *default_conn;
-
 static const struct bt_uuid_128 golioth_svc_uuid = BT_UUID_INIT_128(GOLIOTH_BLE_GATT_UUID_SVC_VAL);
 
 static bool data_cb(struct bt_data *data, void *user_data)
@@ -99,10 +97,8 @@ static void device_found(const bt_addr_le_t *addr,
             return;
         }
 
-        err = bt_conn_le_create(addr,
-                                BT_CONN_LE_CREATE_CONN,
-                                BT_LE_CONN_PARAM_DEFAULT,
-                                &default_conn);
+        struct bt_conn *conn = NULL;
+        err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &conn);
         if (err)
         {
             LOG_ERR("Create auto conn to failed (%d)", err);


### PR DESCRIPTION
We do not use the returned bt_conn reference, so there is no need to keep it. Using a local variable initialized to NULL also suppresses a warning about reusing connection references.