### PR TITLE
bt: handle errors during connection

### DIFF
--- a/gateway/src/bt/connect.c
+++ b/gateway/src/bt/connect.c
@@ -126,6 +126,8 @@ static void bt_connected(struct bt_conn *conn, uint8_t err)
     {
         LOG_ERR("Failed to connect to %s %u %s", addr, err, bt_hci_err_to_str(err));
 
+        bt_conn_unref(conn);
+
         gateway_scan_start();
         return;
     }
@@ -147,6 +149,7 @@ static void bt_connected(struct bt_conn *conn, uint8_t err)
     if (err)
     {
         LOG_ERR("Failed to start discovery: %d", err);
+        bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
     }
 }
 

--- a/gateway/src/bt/scan.c
+++ b/gateway/src/bt/scan.c
@@ -14,6 +14,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(scan);
 
+#include <gateway/bt/scan.h>
+
 static inline bool version_is_compatible(const struct golioth_ble_gatt_adv_data *adv_data)
 {
     uint8_t self_ver = adv_data->version
@@ -101,7 +103,8 @@ static void device_found(const bt_addr_le_t *addr,
         err = bt_conn_le_create(addr, BT_CONN_LE_CREATE_CONN, BT_LE_CONN_PARAM_DEFAULT, &conn);
         if (err)
         {
-            LOG_ERR("Create auto conn to failed (%d)", err);
+            LOG_ERR("Create auto conn failed (%d)", err);
+            gateway_scan_start();
             return;
         }
     }


### PR DESCRIPTION
Ensure that we properly disconnect and unref the connection if we encounter errors during connection or discovery. This ensures that the gateway is able to resume scanning and syncing other nodes.

Fixes golioth/firmware-issue-tracker#822