### PR TITLE
gateway: certs: handle large server certs

### DIFF
--- a/gateway/src/cert.c
+++ b/gateway/src/cert.c
@@ -146,7 +146,7 @@ void cert_module_on_connected(struct golioth_client *client)
     if (IS_ENABLED(CONFIG_GATEWAY_CLOUD))
     {
         size_t len = sizeof(server_crt_buf);
-        status = golioth_gateway_server_cert_get(client, server_crt_buf, &len, 5);
+        status = golioth_gateway_server_cert_get(client, server_crt_buf, &len);
         if (status != GOLIOTH_OK)
         {
             LOG_ERR("Failed to download server certificate: %d", status);

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -4,7 +4,7 @@ manifest:
   projects:
     - name: golioth
       path: modules/lib/golioth-firmware-sdk
-      revision: 0526994c832538586019765b886c9fc10d5e8387
+      revision: 14663e73d824a5638fd010d3bc0067ce5a5a08c6
       url: https://github.com/golioth/golioth-firmware-sdk.git
       import:
         file: west-ncs.yml

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -4,7 +4,7 @@ manifest:
   projects:
     - name: golioth
       path: modules/lib/golioth-firmware-sdk
-      revision: 0526994c832538586019765b886c9fc10d5e8387
+      revision: 14663e73d824a5638fd010d3bc0067ce5a5a08c6
       url: https://github.com/golioth/golioth-firmware-sdk.git
       import:
         file: west-zephyr.yml


### PR DESCRIPTION
If the server cert (chain) is larger than 1024 bytes, the server sends a blockwise response. This updates the golioth reference to bring in a change that handles the blockwise response.