### PR TITLE
ci: add merged.hex to artifacts for NCS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,4 +106,6 @@ jobs:
             build/${{ matrix.sysbuild && matrix.app || '' }}/zephyr/zephyr.hex
             build/${{ matrix.sysbuild && matrix.app || '' }}/zephyr/zephyr.elf
             build/${{ matrix.sysbuild && matrix.app || '' }}/zephyr/zephyr.map
+            ${{ ((matrix.manifest == 'west-ncs.yml') && 'build/merged.hex') || '' }}
+            ${{ ((matrix.manifest == 'west-thingy91x-controller.yml') && 'build/merged.hex') || '' }}
             ${{ (matrix.sysbuild && (matrix.manifest == 'west-ncs.yml') && 'build/dfu_application.zip') || '' }}


### PR DESCRIPTION
merged.hex contains bootloader and application, so it makes sense to upload that for reproducibility purposes.