### PR TITLE
downlink: ensure disconnection after aborted downlink

### DIFF
--- a/gateway/src/downlink.c
+++ b/gateway/src/downlink.c
@@ -155,6 +155,7 @@ int downlink_get_data(struct downlink_context *downlink, void *dst, size_t *dst_
                 {
                     /* We have aborted the downlink and the block queue is empty */
                     *is_last = true;
+                    atomic_set_bit(downlink->flags, DOWNLINK_FLAG_COMPLETE);
                     return 0;
                 }
                 if (0 == *dst_len)


### PR DESCRIPTION
To ensure that the GATT layer disconnects after an aborted downlink, mark the downlink as complete after the block queue has been drained.