### PR TITLE
gateway: reduce default number of cache blocks

### DIFF
--- a/gateway/Kconfig
+++ b/gateway/Kconfig
@@ -28,7 +28,7 @@ endif # GATEWAY_CLOUD
 
 config GATEWAY_NUM_BLOCKS
     int "Number of blocks in downlink/uplink buffer"
-    default 32
+    default 10
     help
       The number of blocks available for buffering uplink or downlink
       data between a node device and the cloud. Each block is equal


### PR DESCRIPTION
Reduces the default number of cache blocks to a reasonable value that
balances performance and resource usage.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>