### PR TITLE
thingy91x: include app core artifacts and programming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,4 +109,6 @@ jobs:
             build/${{ matrix.sysbuild && matrix.app || '' }}/zephyr/zephyr.map
             ${{ ((matrix.manifest == 'west-ncs.yml') && 'build/merged.hex') || '' }}
             ${{ ((matrix.manifest == 'west-thingy91x-controller.yml') && 'build/merged.hex') || '' }}
+            ${{ ((matrix.manifest == 'west-thingy91x-controller.yml') && 'build/merged_CPUAPP.hex') || '' }}
+            ${{ ((matrix.manifest == 'west-thingy91x-controller.yml') && 'build/empty_app_core/zephyr/zephyr.elf') || '' }}
             ${{ (matrix.sysbuild && (matrix.manifest == 'west-ncs.yml') && 'build/dfu_application.zip') || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,14 @@ jobs:
             release/thingy91x_nrf9151.hex
           mv artifacts/gateway-thingy91x-nrf9151-ns/gateway/zephyr/zephyr.elf \
             release/thingy91x_nrf9151_ns.elf
+          mv artifacts/controller-thingy91x-nrf5340-cpunet/merged_CPUAPP.hex \
+            release/thingy91x_nrf5340_cpuapp.hex
+          mv artifacts/controller-thingy91x-nrf5340-cpunet/empty_app_core/zephyr/zephyr.elf \
+            release/thingy91x_nrf5340_cpuapp.elf
           mv artifacts/controller-thingy91x-nrf5340-cpunet/merged.hex \
-            release/thingy91x_nrf5340.hex
+            release/thingy91x_nrf5340_cpunet.hex
           mv artifacts/controller-thingy91x-nrf5340-cpunet/controller/zephyr/zephyr.elf \
-            release/thingy91x_nrf5340.elf
+            release/thingy91x_nrf5340_cpunet.elf
 
           mv artifacts/gateway-frdm_rw612/zephyr.hex \
             release/frdm_rw612.hex

--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ CLI tool.
 
     a. Position the SWD selection switch (`SW2`) to `nRF53`
 
-    b. Issue the following command:
+    b. Issue the following command to program the `app` core:
     ```
-    nrfutil device program --firmware thingy91x_nrf5340.hex --x-family nrf53
+    nrfutil device program --firmware thingy91x_nrf5340_cpuapp.hex --x-family nrf53 --core application
     ```
+    c. Issue the following command to program the `net` core:
+    ```
+    nrfutil device program --firmware thingy91x_nrf5340_cpunet.hex --x-family nrf53 --core network
 3. Program the nRF9151 Gateway Firmware
 
     a. Power cycle the device and position the SWD selection switch (`SW2`) to


### PR DESCRIPTION
Updates thingy91x build and programming instructions to include app core firmware. This ensures that the network core firmware is not disrupted by existing firmware on the app core.