### PR TITLE
zephyr: add requirements.txt to package-managers in module.yml

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -7,3 +7,7 @@ samples:
   - samples
 runners:
   - file: scripts/runners/__init__.py
+package-managers:
+  pip:
+    requirement-files:
+      - requirements.txt


### PR DESCRIPTION
This allows to install all requirements (Zephyr, mcuboot and pouch) with:

```
  west packages pip --install
```